### PR TITLE
Added feature for aws_auth configuration and additional rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ In this module, we have implemented the following CIS Compliance checks for EKS:
 | <a name="input_cluster_log_retention_in_days"></a> [cluster\_log\_retention\_in\_days](#input\_cluster\_log\_retention\_in\_days) | Retention period for EKS cluster logs in days. Default is set to 90 days. | `number` | `90` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | Private subnets of the VPC which can be used by EKS | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 | <a name="input_create_kms_key"></a> [create\_kms\_key](#input\_create\_kms\_key) | Controls if a KMS key for cluster encryption should be created | `bool` | `false` | no |
+| <a name="input_additional_rules"></a> [additional\_rules](#input\_additional\_rules) | List of additional security group rules to add to the cluster security group created. | `any` | `{}` | no |
+| <a name="input_create_aws_auth_configmap"></a> [create\_aws\_auth\_configmap](#input\_create\_aws\_auth\_configmap) | Determines whether to manage the aws-auth configmap | `bool` | `false` | no |
+| <a name="input_aws_auth_users"></a> [aws\_auth\_users](#input\_aws\_auth\_users) | List of user maps to add to the aws-auth configmap | `any` | `[]` | no |
 
 ## Outputs
 
@@ -133,6 +136,7 @@ In this module, we have implemented the following CIS Compliance checks for EKS:
 | <a name="output_worker_iam_role_arn"></a> [worker\_iam\_role\_arn](#output\_worker\_iam\_role\_arn) | ARN of the IAM role assigned to the EKS worker nodes. |
 | <a name="output_worker_iam_role_name"></a> [worker\_iam\_role\_name](#output\_worker\_iam\_role\_name) | Name of the IAM role assigned to the EKS worker nodes. |
 | <a name="output_kms_policy_arn"></a> [kms\_policy\_arn](#output\_kms\_policy\_arn) | ARN of the KMS policy that is used by the EKS cluster. |
+| <a name="output_cluster_certificate_authority_data"></a> [cluster\_certificate\_authority\_data](#output\_cluster\_certificate\_authority\_data) | Base64 encoded certificate data required to communicate with the cluster |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contribution & Issue Reporting

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ module "eks" {
   kms_key_arn                          = "arn:aws:kms:us-east-2:222222222222:key/kms_key_arn"
   create_aws_auth_configmap            = true
   aws_auth_users                       = []
+  aws_auth_roles                       = []
   additional_rules                     = {}
   cluster_version                      = "1.25"
   cluster_log_types                    = ["api", "scheduler"]
@@ -126,6 +127,7 @@ In this module, we have implemented the following CIS Compliance checks for EKS:
 | <a name="input_additional_rules"></a> [additional\_rules](#input\_additional\_rules) | List of additional security group rules to add to the cluster security group created. | `any` | `{}` | no |
 | <a name="input_create_aws_auth_configmap"></a> [create\_aws\_auth\_configmap](#input\_create\_aws\_auth\_configmap) | Determines whether to manage the aws-auth configmap | `bool` | `false` | no |
 | <a name="input_aws_auth_users"></a> [aws\_auth\_users](#input\_aws\_auth\_users) | List of user maps to add to the aws-auth configmap | `any` | `[]` | no |
+| <a name="input_aws_auth_roles"></a> [aws\_auth\_roles](#input\_aws\_auth\_roles) | List of role maps to add to the aws-auth configmap | `list(any)` | `[]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ module "eks" {
   vpc_id                               = module.vpc.vpc_id
   environment                          = "production"
   kms_key_arn                          = "arn:aws:kms:us-east-2:222222222222:key/kms_key_arn"
+  create_aws_auth_configmap            = true
+  aws_auth_users                       = []
+  additional_rules                     = {}
   cluster_version                      = "1.25"
   cluster_log_types                    = ["api", "scheduler"]
   private_subnet_ids                   = ["subnet-00exyzf967d21w","subnet-00exyzd967sqop"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -58,6 +58,24 @@ module "eks" {
   cluster_log_retention_in_days        = 30
   cluster_endpoint_public_access       = true
   cluster_endpoint_public_access_cidrs = ["0.0.0.0/0"]
+  create_aws_auth_configmap            = true
+  aws_auth_users = [
+    {
+      userarn  = "arn:aws:iam::222222222222:user/aws-user"
+      username = "aws-user"
+      groups   = ["system:masters"]
+    },
+  ]
+  additional_rules = {
+    ingress_port_mgmt_tcp = {
+      description = "mgmt vpc cidr"
+      protocol    = "tcp"
+      from_port   = 443
+      to_port     = 443
+      type        = "ingress"
+      cidr_blocks = ["172.10.0.0/16"]
+    }
+  }
 }
 
 module "managed_node_group_production" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -59,6 +59,13 @@ module "eks" {
   cluster_endpoint_public_access       = true
   cluster_endpoint_public_access_cidrs = ["0.0.0.0/0"]
   create_aws_auth_configmap            = true
+  aws_auth_roles = [
+    {
+      rolearn  = "arn:aws:iam::222222222222:role/service-role"
+      username = "username"
+      groups   = ["system:masters"]
+    }
+  ]
   aws_auth_users = [
     {
       userarn  = "arn:aws:iam::222222222222:user/aws-user"

--- a/examples/complete/provider.tf
+++ b/examples/complete/provider.tf
@@ -4,3 +4,15 @@ provider "aws" {
     tags = local.additional_aws_tags
   }
 }
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    # This requires the awscli to be installed locally where Terraform is executed
+    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -12,10 +12,14 @@ module "eks" {
     "Name"        = format("%s-%s", var.environment, var.name)
     "Environment" = var.environment
   }
-  cluster_endpoint_public_access         = var.cluster_endpoint_public_access
-  cluster_endpoint_private_access        = var.cluster_endpoint_public_access ? false : true
-  cluster_endpoint_public_access_cidrs   = var.cluster_endpoint_public_access_cidrs
-  cloudwatch_log_group_retention_in_days = var.cluster_log_retention_in_days
+  aws_auth_users                          = var.aws_auth_users
+  create_aws_auth_configmap               = var.create_aws_auth_configmap
+  manage_aws_auth_configmap               = var.create_aws_auth_configmap
+  cluster_security_group_additional_rules = var.additional_rules
+  cluster_endpoint_public_access          = var.cluster_endpoint_public_access
+  cluster_endpoint_private_access         = var.cluster_endpoint_public_access ? false : true
+  cluster_endpoint_public_access_cidrs    = var.cluster_endpoint_public_access_cidrs
+  cloudwatch_log_group_retention_in_days  = var.cluster_log_retention_in_days
   cluster_encryption_config = {
     provider_key_arn = var.kms_key_arn
     resources        = ["secrets"]

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ module "eks" {
     "Name"        = format("%s-%s", var.environment, var.name)
     "Environment" = var.environment
   }
+  aws_auth_roles                          = var.aws_auth_roles
   aws_auth_users                          = var.aws_auth_users
   create_aws_auth_configmap               = var.create_aws_auth_configmap
   manage_aws_auth_configmap               = var.create_aws_auth_configmap

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "kms_policy_arn" {
   value       = aws_iam_policy.kubernetes_pvc_kms_policy.arn
   description = "ARN of the KMS policy that is used by the EKS cluster."
 }
+
+output "cluster_certificate_authority_data" {
+  description = "Base64 encoded certificate data required to communicate with the cluster"
+  value       = module.eks.cluster_certificate_authority_data
+}

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,21 @@ variable "create_kms_key" {
   type        = bool
   default     = false
 }
+
+variable "additional_rules" {
+  description = "List of additional security group rules to add to the cluster security group created."
+  type        = any
+  default     = {}
+}
+
+variable "create_aws_auth_configmap" {
+  description = "Determines whether to manage the aws-auth configmap"
+  default     = false
+  type        = bool
+}
+
+variable "aws_auth_users" {
+  description = "List of user maps to add to the aws-auth configmap"
+  type        = any
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -81,3 +81,9 @@ variable "aws_auth_users" {
   type        = any
   default     = []
 }
+
+variable "aws_auth_roles" {
+  description = "List of role maps to add to the aws-auth configmap"
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
Release Notes:

1.   Create aws_auth ConfigMap: We have introduced a new feature that automatically creates the aws_auth ConfigMap. This ConfigMap is crucial for managing access control to the EKS cluster, allowing you to define user permissions and roles effortlessly.

 2.  aws_auth_users Configuration: We have added the ability to specify IAM users that should have access to the EKS cluster using the new aws_auth_users configuration block. This feature simplifies user access management and enables you to control user permissions easily.

 3.  aws_auth_roles Configuration: With the new aws_auth_roles configuration block, you can now define IAM roles that should have access to the EKS cluster. This enhancement provides more flexibility in managing access for different roles within your organization.

  4. Additional Rules: We have expanded the module's functionality to support additional rules for ingress and egress traffic. You can now define custom networking rules for your EKS cluster, giving you more control over network traffic.
 
 