### PR TITLE
Adding length validation for launch_template_name in variable.tf

### DIFF
--- a/modules/managed-nodegroup/main.tf
+++ b/modules/managed-nodegroup/main.tf
@@ -1,5 +1,5 @@
 locals{
-  computed_launch_template_name = format("%s-%s-%s", var.environment, var.managed_ng_name, "launch-template")
+  launch_template_name = format("%s-%s-%s", var.eks_cluster_name, var.managed_ng_name, "lt")
 }
 
 data "aws_eks_cluster" "eks" {
@@ -39,7 +39,7 @@ data "template_file" "launch_template_userdata" {
 }
 
 resource "aws_launch_template" "eks_template" {
-  name                   = length(var.launch_template_name) > 0 ? var.launch_template_name : local.computed_launch_template_name
+  name                   = length(var.launch_template_name) > 0 ? var.launch_template_name : local.launch_template_name
   key_name               = var.eks_nodes_keypair_name
   image_id               = var.aws_managed_node_group_arch == "arm64" ? data.aws_ami.launch_template_ami_arm64.image_id : data.aws_ami.launch_template_ami_amd64.image_id
   user_data              = base64encode(data.template_file.launch_template_userdata.rendered)

--- a/modules/managed-nodegroup/variables.tf
+++ b/modules/managed-nodegroup/variables.tf
@@ -176,5 +176,10 @@ variable "aws_managed_node_group_arch" {
 variable "launch_template_name" {
   description = "The name of the launch template."
   type        = string
-  default    = ""
+  default     = ""
+
+  validation {
+    condition     = length(var.launch_template_name) <= 60
+    error_message = "The launch_template_name must be 60 characters or fewer. Please provide a shorter name."
+  }
 }


### PR DESCRIPTION
Add a validation block in the variables.tf file for launch_template_name to restrict the name length to a maximum of 60 characters.
Modification done in variable.tf of managed_node_group module








