### PR TITLE
Provide support of additional tags in all the aws resources specifically on eks nodes 

### DIFF
--- a/examples/complete-ipv6/main.tf
+++ b/examples/complete-ipv6/main.tf
@@ -6,6 +6,8 @@ locals {
     Owner      = "Organization_name"
     Expires    = "Never"
     Department = "Engineering"
+    Product    = ""
+    Environment = local.environment
   }
   kms_user              = null
   vpc_cidr              = "10.10.0.0/16"

--- a/examples/complete-ipv6/main.tf
+++ b/examples/complete-ipv6/main.tf
@@ -6,8 +6,6 @@ locals {
     Owner      = "Organization_name"
     Expires    = "Never"
     Department = "Engineering"
-    Product    = ""
-    Environment = local.environment
   }
   kms_user              = null
   vpc_cidr              = "10.10.0.0/16"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -38,8 +38,6 @@ locals {
     Owner      = "Organization_name"
     Expires    = "Never"
     Department = "Engineering"
-    Product    = ""
-    Environment = local.environment
   }
   aws_managed_node_group_arch = "" #Enter your linux arch (Example:- arm64 or amd64)
   current_identity            = data.aws_caller_identity.current.arn

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -38,6 +38,8 @@ locals {
     Owner      = "Organization_name"
     Expires    = "Never"
     Department = "Engineering"
+    Product    = ""
+    Environment = local.environment
   }
   aws_managed_node_group_arch = "" #Enter your linux arch (Example:- arm64 or amd64)
   current_identity            = data.aws_caller_identity.current.arn

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -180,6 +180,7 @@ module "eks" {
       cidr_blocks = ["10.10.0.0/16"]
     }
   }
+  tags = local.additional_aws_tags
 }
 
 module "managed_node_group_addons" {

--- a/modules/managed-nodegroup/main.tf
+++ b/modules/managed-nodegroup/main.tf
@@ -1,5 +1,5 @@
 locals{
-  computed_launch_template_name = format("%s-%s-%s", var.environment, var.managed_ng_name, "launch-template")
+  launch_template_name = format("%s-%s-%s", var.eks_cluster_name, var.managed_ng_name, "lt")
 }
 
 data "aws_eks_cluster" "eks" {
@@ -39,7 +39,7 @@ data "template_file" "launch_template_userdata" {
 }
 
 resource "aws_launch_template" "eks_template" {
-  name                   = length(var.launch_template_name) > 0 ? var.launch_template_name : local.computed_launch_template_name
+  name                   = length(var.launch_template_name) > 0 ? var.launch_template_name : local.launch_template_name
   key_name               = var.eks_nodes_keypair_name
   image_id               = var.aws_managed_node_group_arch == "arm64" ? data.aws_ami.launch_template_ami_arm64.image_id : data.aws_ami.launch_template_ami_amd64.image_id
   user_data              = base64encode(data.template_file.launch_template_userdata.rendered)

--- a/modules/managed-nodegroup/main.tf
+++ b/modules/managed-nodegroup/main.tf
@@ -69,7 +69,6 @@ resource "aws_launch_template" "eks_template" {
     tags = {
       Name        = format("%s-%s-%s", var.environment, var.managed_ng_name, "eks-node")
       Environment = var.environment
-      Product    = var.tags.Product
     }
   }
 
@@ -102,6 +101,5 @@ resource "aws_eks_node_group" "managed_ng" {
   tags = {
     Name        = format("%s-%s-%s", var.environment, var.managed_ng_name, "ng")
     Environment = var.environment
-    Product    = var.tags.Product
   }
 }

--- a/modules/managed-nodegroup/main.tf
+++ b/modules/managed-nodegroup/main.tf
@@ -66,10 +66,21 @@ resource "aws_launch_template" "eks_template" {
 
   tag_specifications {
     resource_type = "instance"
-    tags = {
-      Name        = format("%s-%s-%s", var.environment, var.managed_ng_name, "eks-node")
-      Environment = var.environment
-    }
+    tags = merge(
+      {
+        Name = format("%s-%s-%s", var.environment, var.managed_ng_name, "eks-node")
+      },
+      var.tags
+    )
+  }
+    tag_specifications {
+    resource_type = "volume"
+    tags = merge(
+      {
+        Name = format("%s-%s-%s", var.environment, var.managed_ng_name, "eks-volume")
+      },
+      var.tags
+    )
   }
 
   lifecycle {

--- a/modules/managed-nodegroup/main.tf
+++ b/modules/managed-nodegroup/main.tf
@@ -109,8 +109,10 @@ resource "aws_eks_node_group" "managed_ng" {
   update_config {
     max_unavailable_percentage = 50
   }
-  tags = {
-    Name        = format("%s-%s-%s", var.environment, var.managed_ng_name, "ng")
-    Environment = var.environment
-  }
+  tags = merge(
+      {
+        Name = format("%s-%s-%s", var.environment, var.managed_ng_name, "ng")
+      },
+      var.tags
+    )
 }

--- a/modules/managed-nodegroup/variables.tf
+++ b/modules/managed-nodegroup/variables.tf
@@ -176,5 +176,10 @@ variable "aws_managed_node_group_arch" {
 variable "launch_template_name" {
   description = "The name of the launch template."
   type        = string
-  default    = ""
+  default     = ""
+
+  validation {
+    condition     = length(var.launch_template_name) <= 60
+    error_message = "The launch_template_name must be 60 characters or fewer. Please provide a shorter name."
+  }
 }


### PR DESCRIPTION
1. Changes  done in the module - Provide additional tags support in all the resources in the terraform-aws-eks module.
2. Made changes in the main.tf of calling module and add the two cost related tags in the additional_aws_tags .
3. Made changes in the main.tf of modules managed_node_group in launch_template resource to support additional tags in eks nodes.