### PR TITLE
added coreDNS

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -203,6 +203,7 @@ module "managed_node_group_addons" {
   managed_ng_instance_types   = ["t3a.large", "t3.large", "t3.medium"] # Pass instance type according to the ami architecture.
   managed_ng_kms_policy_arn   = module.eks.kms_policy_arn
   associate_public_ip_address = false
+  enable_coredns_addon        = true
   managed_ng_node_autorepair = {
     enabled                            = false
     enable_node_monitoring_agent_addon = true

--- a/modules/managed-nodegroup/main.tf
+++ b/modules/managed-nodegroup/main.tf
@@ -165,3 +165,26 @@ resource "aws_eks_addon" "node_monitoring_addon" {
     }
   })
 }
+
+resource "aws_eks_addon" "coredns" {
+  count = var.enable_coredns_addon ? 1:0
+  depends_on = [ aws_eks_node_group.managed_ng ]
+  cluster_name                = var.eks_cluster_name
+  addon_name                  = "coredns"
+  addon_version               = "v1.11.4-eksbuild.2"
+  resolve_conflicts_on_create = "OVERWRITE"
+  configuration_values = jsonencode({
+    replicaCount = 4
+    resources = {
+      limits = {
+        cpu    = "100m"
+        memory = "150Mi"
+      }
+      requests = {
+        cpu    = "100m"
+        memory = "150Mi"
+      }
+    }
+  })
+
+}

--- a/modules/managed-nodegroup/main.tf
+++ b/modules/managed-nodegroup/main.tf
@@ -174,7 +174,7 @@ resource "aws_eks_addon" "coredns" {
   addon_version               = "v1.11.4-eksbuild.2"
   resolve_conflicts_on_create = "OVERWRITE"
   configuration_values = jsonencode({
-    replicaCount = 4
+    replicaCount = 2
     resources = {
       limits = {
         cpu    = "100m"

--- a/modules/managed-nodegroup/variables.tf
+++ b/modules/managed-nodegroup/variables.tf
@@ -216,3 +216,9 @@ variable "managed_ng_node_autorepair" {
     enable_node_monitoring_agent_addon = false
   }
 }
+
+variable "enable_coredns_addon" {
+  type        = bool
+  description = "Enable CoreDNS addon"
+  default     = true
+}


### PR DESCRIPTION
- Added **coreDNS** in managed-nodegroup
- Also Added **depends_on = [ aws_eks_node_group.managed_ng ]** in creDNS module to make sure coreDNS is created after the nodegroup. 
- Created a variable to enable coreDNS